### PR TITLE
Append trailing newline to each certificate in output

### DIFF
--- a/cmd/certsplitter/main.go
+++ b/cmd/certsplitter/main.go
@@ -78,12 +78,16 @@ func printUsage() {
 }
 
 func splitCerts(certs string) []string {
-	result := strings.SplitAfter(certs, "-----END CERTIFICATE-----")
-	for i, cert := range result {
-		start := strings.Index(cert, "-----BEGIN CERTIFICATE-----")
-		if start > 0 {
-			result[i] = cert[start:len(cert)]
+	chunks := strings.SplitAfter(certs, "-----END CERTIFICATE-----")
+	result := []string{}
+	for _, chunk := range chunks {
+		start := strings.Index(chunk, "-----BEGIN CERTIFICATE-----")
+		if start == -1 {
+			continue
 		}
+
+		cert := chunk[start:len(chunk)] + "\n"
+		result = append(result, cert)
 	}
-	return result[:len(result)-1]
+	return result
 }

--- a/cmd/certsplitter/main.go
+++ b/cmd/certsplitter/main.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	certFileFmt = "trusted_ca_%d.crt"
+	certFileFmt = "trusted-ca-%d.crt"
 )
 
 type Certs struct {

--- a/cmd/certsplitter/main.go
+++ b/cmd/certsplitter/main.go
@@ -12,6 +12,10 @@ import (
 	"strings"
 )
 
+const (
+	certFileFmt = "trusted_ca_%d.crt"
+)
+
 type Certs struct {
 	TrustedCACertificates []string `json:"trusted_ca_certificates"`
 }
@@ -48,18 +52,17 @@ func main() {
 	}
 
 	certs := Certs{}
-	certFileFmt := "trusted_ca_%d.crt"
 	if strings.Contains(trustedCertsPath, ".json") {
 		err := json.Unmarshal(data, &certs)
 		if err != nil {
 			log.Println(err)
 			os.Exit(1)
 		}
-		certs.fixCerts()
-		certFileFmt = "container-trusted-ca-%d.crt"
 	} else {
-		certs = Certs{TrustedCACertificates: splitCerts(string(data))}
+		certs = Certs{TrustedCACertificates: []string{string(data)}}
 	}
+
+	certs.fixCerts()
 
 	outputDir := flag.Args()[1]
 	for i, c := range certs.TrustedCACertificates {

--- a/cmd/certsplitter/main_test.go
+++ b/cmd/certsplitter/main_test.go
@@ -61,6 +61,7 @@ var _ = Describe("Certsplitter", func() {
 				data, err := ioutil.ReadFile(path)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(bytes.HasPrefix(data, []byte("-----BEGIN CERTIFICATE-----"))).To(BeTrue())
+				Expect(bytes.HasSuffix(data, []byte("-----END CERTIFICATE-----\n"))).To(BeTrue(), "cert file does not end in newline")
 
 				block, rest := pem.Decode(data)
 				Expect(rest).To(BeEmpty())
@@ -101,6 +102,7 @@ var _ = Describe("Certsplitter", func() {
 					data, err := ioutil.ReadFile(path)
 					Expect(err).NotTo(HaveOccurred())
 					Expect(bytes.HasPrefix(data, []byte("-----BEGIN CERTIFICATE-----"))).To(BeTrue())
+					Expect(bytes.HasSuffix(data, []byte("-----END CERTIFICATE-----\n"))).To(BeTrue(), "cert file does not end in newline")
 
 					block, rest := pem.Decode(data)
 					Expect(rest).To(BeEmpty())

--- a/cmd/certsplitter/main_test.go
+++ b/cmd/certsplitter/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -57,7 +58,7 @@ var _ = Describe("Certsplitter", func() {
 
 				// Files are walked in lexical order
 				count++
-				Expect(filepath.Base(path)).To(Equal(fmt.Sprintf("trusted_ca_%d.crt", count)))
+				Expect(strings.HasSuffix(filepath.Base(path), fmt.Sprintf("%d.crt", count))).To(BeTrue(), "cert filename does not end with sequence number")
 				data, err := ioutil.ReadFile(path)
 				Expect(err).NotTo(HaveOccurred())
 				Expect(bytes.HasPrefix(data, []byte("-----BEGIN CERTIFICATE-----"))).To(BeTrue())


### PR DESCRIPTION
Also regularize the output filenames and dry up main.